### PR TITLE
Fix restoring wallet from mnemonic after ethereumjs-util upgrade

### DIFF
--- a/src/plugins/fantom-web3-wallet.js
+++ b/src/plugins/fantom-web3-wallet.js
@@ -392,7 +392,7 @@ export class FantomWeb3Wallet {
         const root = Hdkey.fromMasterSeed(seed);
         const addrNode = root.derive("m/44'/60'/0'/0/0");
         const pubKey = ethUtil.privateToPublic(addrNode._privateKey);
-        const addr = ethUtil.publicToAddress(pubKey).toString('hex');
+        const addr = '0x' + ethUtil.publicToAddress(pubKey).toString('hex');
         const publicAddress = ethUtil.toChecksumAddress(addr);
         const privateKey = ethUtil.bufferToHex(addrNode._privateKey);
 


### PR DESCRIPTION
Before this fix, when trying to restore wallet from mnemonic, following error occures:

```
Error: "This method only supports 0x-prefixed hex strings but input was: 83a6524be9213b1ce36bcc0dcefb5eb51d87ad10"
    assertIsHexString helpers.js:11
    toChecksumAddress account.js:44
    mnemonicToKeys fantom-web3-wallet.js:396
```

This is because toChecksumAddress in ethereumjs-util newly requires address prefixed by '0x'.
Because hash function never outputs it, it have to be added here.